### PR TITLE
Add option for sorting RSS feed by date

### DIFF
--- a/autogen.js
+++ b/autogen.js
@@ -17,6 +17,8 @@ program
   .option('-p, --playlist <playlistUrl>', 'Process all videos in a YouTube playlist')
   .option('-u, --urls <filePath>', 'Process YouTube videos from a list of URLs in a file')
   .option('-r, --rss <rssUrl>', 'Process podcast episodes from an RSS feed')
+  .option('--oldest', 'Process items from oldest to newest (default)')
+  .option('--newest', 'Process items from newest to oldest')
   .option('-m, --model <type>', 'Select model to use: base, medium, or large', 'large')
   .option('--chatgpt', 'Generate show notes with ChatGPT')
   .option('--claude', 'Generate show notes with Claude')
@@ -29,14 +31,21 @@ program
 
 program.action(async (options) => {
   const model = getModel(options.model)
-  const { chatgpt, claude, cohere, mistral, octo, deepgram, assembly, profile } = options
+  const { chatgpt, claude, cohere, mistral, octo, deepgram, assembly, profile, oldest, newest } = options
   const commonArgs = [ model, chatgpt, claude, cohere, mistral, octo, deepgram, assembly ]
+
+  let order = 'oldest' // Default order
+  if (newest) {
+    order = 'newest'
+  } else if (oldest) {
+    order = 'oldest'
+  }
 
   const handlers = {
     video: processVideo,
     playlist: processPlaylist,
     urls: processUrlsFile,
-    rss: processRssFeed,
+    rss: (url, model) => processRssFeed(url, model, order),
   }
 
   for (const [key, handler] of Object.entries(handlers)) {

--- a/commands/processRssFeed.js
+++ b/commands/processRssFeed.js
@@ -27,7 +27,7 @@ async function processRssItem(item, model) {
     ].join('\n')
 
     fs.writeFileSync(`${id}.md`, mdContent)
-    console.log(`Markdown file completed successfully: ${id}.md`)
+    console.log(`\n\nMarkdown file completed successfully: ${id}.md`)
 
     execSync(`${ffmpegPath} -i "${item.showLink}" -ar 16000 "${id}.wav"`, { stdio: 'ignore' })
     console.log(`WAV file completed successfully: ${id}.wav`)
@@ -42,13 +42,13 @@ async function processRssItem(item, model) {
     console.log(`Prompt concatenated to transformed transcript successfully: ${id}.md`)
 
     cleanUpFiles(id)
-    console.log(`Process completed successfully for RSS item: ${item.title}`)
+    console.log(`\n\nProcess completed successfully for RSS item: ${item.title}`)
   } catch (error) {
     console.error(`Error processing RSS item: ${item.title}`, error)
   }
 }
 
-export async function processRssFeed(rssUrl, model) {
+export async function processRssFeed(rssUrl, model, order) {
   try {
     const response = await fetch(rssUrl, {
       method: 'GET',
@@ -82,9 +82,11 @@ export async function processRssFeed(rssUrl, model) {
       title: item.title,
       publishDate: dateFormatter.format(new Date(item.pubDate)),
       coverImage: item['itunes:image']?.href || channelImage,
-    })).reverse()
+    }))
 
-    for (const item of items) {
+    const sortedItems = order === 'newest' ? items : [...items].reverse()
+
+    for (const item of sortedItems) {
       await processRssItem(item, model)
     }
   } catch (error) {

--- a/commands/processVideo.js
+++ b/commands/processVideo.js
@@ -93,7 +93,7 @@ export async function processVideo(url, model, chatgpt, claude, cohere, mistral,
       }
 
       cleanUpFiles(id)
-      console.log(`Process completed successfully for URL:\n  - ${url}`)
+      console.log(`\n\nProcess completed successfully for URL: ${url}\n`)
     })
   } catch (error) {
     console.error(`Error processing video: ${url}`, error)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -50,7 +50,14 @@ npm run autoshow -- --urls urls.md
 Run on an RSS podcast feed.
 
 ```bash
+# Process RSS feed from oldest to newest (default behavior)
 npm run autoshow -- --rss "https://feeds.transistor.fm/fsjam-podcast/"
+
+# Explicitly process RSS feed from oldest to newest
+npm run autoshow -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --oldest
+
+# Process RSS feed from newest to oldest
+npm run autoshow -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --newest
 ```
 
 ## Language Model (LLM) Options


### PR DESCRIPTION
Podcast RSS feeds tend to sort episodes by date with the newest episodes at the top of the feed. This PR adds options for configuring whether the episodes will be processed starting with the oldest or the newest episodes first.

By default the feed will process oldest to newest

```bash
npm run autoshow -- --rss "https://feeds.transistor.fm/fsjam-podcast/"
```

Passing `--oldest` retains the default behavior:

```bash
npm run autoshow -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --oldest
```

Passing `--newest` reverses the order and starts by processing the most recent episodes:

```bash
npm run autoshow -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --newest
```