### PR TITLE
Refactor Part 2 and Skip Option for RSS

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ This sets a default model for Llama.cpp which ensures `--llama` doesn't fail if 
 Install `yt-dlp`, `ffmpeg`, and run `npm i`.
 
 ```bash
-brew install yt-dlp ffmpeg llama.cpp
+brew install yt-dlp ffmpeg
 npm i
 ```
 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -53,7 +53,7 @@ npm run autoshow -- --urls "content/examples/urls.md"
 ### Process Single Audio or Video File
 
 ```bash
-npm run autoshow -- --file "content/examples/example.mp3"
+npm run autoshow -- --file "content/examples/audio.mp3"
 ```
 
 ### Process Podcast RSS Feed

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "autoshow": "./autoshow.js"
   },
   "scripts": {
-    "autoshow": "node --env-file=.env src/autoshow.js",
-    "as": "node --env-file=.env src/autoshow.js",
+    "autoshow": "node --env-file=.env --no-warnings src/autoshow.js",
+    "as": "node --env-file=.env --no-warnings src/autoshow.js",
     "serve": "node --env-file=.env --no-warnings --watch server/index.js",
     "fetch": "node --env-file=.env --no-warnings server/fetch.js"
   },

--- a/src/autoshow.js
+++ b/src/autoshow.js
@@ -6,8 +6,8 @@ import { Command } from 'commander'
 import { processVideo } from './commands/processVideo.js'
 import { processPlaylist } from './commands/processPlaylist.js'
 import { processURLs } from './commands/processURLs.js'
-import { processRSS } from './commands/processRSS.js'
 import { processFile } from './commands/processFile.js'
+import { processRSS } from './commands/processRSS.js'
 import { env } from 'node:process'
 
 const program = new Command()
@@ -21,6 +21,7 @@ program
   .option('-f, --file <filePath>', 'Process a local audio or video file')
   .option('-r, --rss <rssURL>', 'Process a podcast RSS feed')
   .option('--order <order>', 'Specify the order for RSS feed processing (newest or oldest)', 'newest')
+  .option('--skip <number>', 'Number of items to skip when processing RSS feed', parseInt, 0)
   .option('--whisper <modelType>', 'Specify the Whisper model type', 'base')
   .option('--chatgpt', 'Use ChatGPT for processing')
   .option('--claude', 'Use Claude for processing')
@@ -49,7 +50,7 @@ program.action(async (options) => {
   for (const [key, handler] of Object.entries(handlers)) {
     if (options[key]) {
       if (key === 'rss') {
-        await handler(options[key], llmOption, transcriptionOption, options.order)
+        await handler(options[key], llmOption, transcriptionOption, options.order, options.skip)
       } else {
         await handler(options[key], llmOption, transcriptionOption)
       }

--- a/src/commands/processFile.js
+++ b/src/commands/processFile.js
@@ -1,52 +1,45 @@
 // src/commands/processFile.js
 
-import { readFile } from 'node:fs/promises'
+import { readFile, access } from 'node:fs/promises'
 import { exec } from 'node:child_process'
 import { promisify } from 'node:util'
+import { basename } from 'node:path'
 import { fileTypeFromBuffer } from 'file-type'
 import ffmpeg from 'ffmpeg-static'
-import { runTranscription, runLLM, cleanUpFiles } from '../utils/exports.js'
+import { runTranscription } from '../utils/runTranscription.js'
+import { runLLM } from '../utils/runLLM.js'
+import { cleanUpFiles } from '../utils/cleanUpFiles.js'
 
 const execPromise = promisify(exec)
 
-async function convertFile(filePath) {
+async function downloadFileAudio(filePath) {
+  const supportedFormats = new Set(['wav', 'mp3', 'm4a', 'aac', 'ogg', 'flac', 'mp4', 'mkv', 'avi', 'mov', 'webm'])
   try {
+    await access(filePath)
     const buffer = await readFile(filePath)
+    console.log(`File read successfully. Buffer length: ${buffer.length}\nDetermining file type...`)
     const fileType = await fileTypeFromBuffer(buffer)
-    if (!fileType) {
-      throw new Error('Unable to determine file type')
+    if (!fileType || !supportedFormats.has(fileType.ext)) {
+      throw new Error(fileType ? `Unsupported file type: ${fileType.ext}` : 'Unable to determine file type')
     }
     console.log(`Detected file type: ${fileType.ext}`)
-
-    const formats = ['wav', 'mp3', 'm4a', 'aac', 'ogg', 'flac', 'mp4', 'mkv', 'avi', 'mov', 'webm']
-    if (!formats.includes(fileType.ext)) {
-      throw new Error(`Unsupported file type: ${fileType.ext}`)
-    }
-
     if (fileType.ext !== 'wav') {
-      try {
-        await execPromise(`${ffmpeg} -i "${filePath}" -acodec pcm_s16le -ar 16000 -ac 1 "${filePath}.wav"`)
-        console.log(`Converted ${filePath} to ${filePath}.wav`)
-      } catch (error) {
-        console.error('Error converting file:', error)
-        throw error
-      }
+      await execPromise(`${ffmpeg} -i "${filePath}" -acodec pcm_s16le -ar 16000 -ac 1 "${filePath}.wav"`)
+      console.log(`Converted ${filePath} to ${filePath}.wav`)
     } else {
       await execPromise(`cp "${filePath}" "${filePath}.wav"`)
     }
     return filePath
   } catch (error) {
-    console.error('Error in convertFile:', error)
+    console.error('Error in downloadFileAudio:', error.message)
     throw error
   }
 }
 
 export async function processFile(filePath, llmOption, whisperModelType) {
   try {
-    const finalPath = await convertFile(filePath)
-    const frontMatter = `---
-title: "${filePath}"
----\n`
+    const finalPath = await downloadFileAudio(filePath)
+    const frontMatter = `---\ntitle: "${basename(filePath)}"\n---\n`
     await runTranscription(finalPath, whisperModelType, frontMatter)
     await runLLM(finalPath, frontMatter, llmOption)
     await cleanUpFiles(finalPath)

--- a/src/commands/processVideo.js
+++ b/src/commands/processVideo.js
@@ -1,11 +1,13 @@
 // src/commands/processVideo.js
 
 import { writeFile } from 'node:fs/promises'
-import {
-  generateMarkdown, downloadAudio, runTranscription, runLLM, cleanUpFiles
-} from '../utils/exports.js'
+import { generateMarkdown } from '../utils/generateMarkdown.js'
+import { downloadAudio } from '../utils/downloadAudio.js'
+import { runTranscription } from '../utils/runTranscription.js'
+import { runLLM } from '../utils/runLLM.js'
+import { cleanUpFiles } from '../utils/cleanUpFiles.js'
 
-export const processVideo = async (url, llmOption, transcriptionOption) => {
+export async function processVideo(url, llmOption, transcriptionOption) {
   try {
     const { frontMatter, finalPath, filename } = await generateMarkdown(url)
     await writeFile(`${finalPath}.md`, frontMatter)

--- a/src/llms/llama.js
+++ b/src/llms/llama.js
@@ -1,4 +1,4 @@
-// src/llms/llamaModule.js
+// src/llms/llama.js
 
 import { writeFile, mkdir } from 'node:fs/promises'
 import { getLlama, LlamaChatSession } from "node-llama-cpp"
@@ -62,10 +62,3 @@ export async function callLlama(transcriptContent, outputFilePath) {
     throw error
   }
 }
-
-// if (require.main === module) {
-//   downloadModel().catch(err => {
-//     console.error('Failed to download model:', err)
-//     process.exit(1)
-//   })
-// }

--- a/src/llms/prompt.js
+++ b/src/llms/prompt.js
@@ -1,25 +1,24 @@
 // src/llms/prompt.js
 
 const summary = {
-  prompt: "- Write a one sentence description of the transcript and a one paragraph summary. The one sentence description shouldn't exceed 180 characters (roughly 30 words). The one paragraph summary should be approximately 600-1200 characters (roughly 100-200 words).\n",
-  example: "One sentence description of the transcript that encapsulates the content contained in the file but does not exceed roughly 180 characters (or approximately 30 words).\n\n  ## Episode Summary\n\n  A concise summary of a chapter's content, typically ranging from 600 to 1200 characters or approximately 100 to 200 words. It begins by introducing the main topic or theme of the chapter, providing context for the reader. The summary then outlines key points or arguments presented in the chapter, touching on major concepts, theories, or findings discussed. It may briefly mention methodologies used or data analyzed, if applicable. The paragraph also highlights any significant conclusions or implications drawn from the chapter's content. Throughout, it maintains a balance between providing enough detail to give readers a clear understanding of the chapter's scope and keeping the information general enough to apply to various subjects. This summary style efficiently conveys the essence of the chapter's content, allowing readers to quickly grasp its main ideas and decide if they want to delve deeper into the full text.\n",
+  prompt: "- Write a one sentence description of the transcript and a one paragraph summary.\n  - The one sentence description shouldn't exceed 180 characters (roughly 30 words).\n  - The one paragraph summary should be approximately 600-1200 characters (roughly 100-200 words).\n",
+  example: "One sentence description of the transcript that encapsulates the content contained in the file but does not exceed roughly 180 characters (or approximately 30 words).\n\n    ## Episode Summary\n\n    A concise summary of a chapter's content, typically ranging from 600 to 1200 characters or approximately 100 to 200 words. It begins by introducing the main topic or theme of the chapter, providing context for the reader. The summary then outlines key points or arguments presented in the chapter, touching on major concepts, theories, or findings discussed. It may briefly mention methodologies used or data analyzed, if applicable. The paragraph also highlights any significant conclusions or implications drawn from the chapter's content. Throughout, it maintains a balance between providing enough detail to give readers a clear understanding of the chapter's scope and keeping the information general enough to apply to various subjects. This summary style efficiently conveys the essence of the chapter's content, allowing readers to quickly grasp its main ideas and decide if they want to delve deeper into the full text.\n",
 }
 
 const chapters = {
-  prompt: "- Create chapters based on the topics discussed throughout. Include timestamps for when these chapters begin. Chapters shouldn't be shorter than 1-2 minutes or longer than 5-6 minutes. Write a one to two paragraph description for each chapter that's at least 75 words or longer. Note the very last timestamp and make sure the chapters extend to the end of the episode.",
-  example: "## Chapters\n\n  00:00 - Introduction and Overview\n\n  A comprehensive description of the content, serving as an overview for readers. It begins by introducing the main themes and concepts that will be explored throughout the chapter. The author outlines several key points, each of which is examined in detail. These points are discussed in terms of their significance and potential impact on various aspects of the subject matter. The text then delves into how these core ideas are applied in practical contexts, highlighting their relevance to current issues and challenges. Throughout the chapter, connections are drawn between different concepts, demonstrating their interrelationships and broader implications within the field of study.\n\n  02:56 - Deep Dive into Topics\n\n  An in-depth examination of a key concept central to the field under discussion. The author, along with contributions from subject matter experts, explores the historical development of this concept, including its foundational principles and advanced applications. The text covers the implementation of this concept across diverse domains, illustrating its impact on improving accuracy in one field, enhancing decision-making processes in another, and revolutionizing a third area. Particular emphasis is placed on the ethical considerations surrounding the application of this concept, specifically addressing concerns about privacy implications, potential biases in its implementation, and its long-term effects on societal structures and practices.",
+  prompt: "- Create chapters based on the topics discussed throughout.\n  - Include timestamps for when these chapters begin.\n  - Chapters shouldn't be shorter than 1-2 minutes or longer than 5-6 minutes.\n  - Write a one to two paragraph description for each chapter that's at least 75 words or longer.\n  - Note the very last timestamp and make sure the chapters extend to the end of the episode.",
+  example: "## Chapters\n\n    00:00 - Introduction and Overview\n\n    A comprehensive description of the content, serving as an overview for readers. It begins by introducing the main themes and concepts that will be explored throughout the chapter. The author outlines several key points, each of which is examined in detail. These points are discussed in terms of their significance and potential impact on various aspects of the subject matter. The text then delves into how these core ideas are applied in practical contexts, highlighting their relevance to current issues and challenges. Throughout the chapter, connections are drawn between different concepts, demonstrating their interrelationships and broader implications within the field of study.",
 }
 
-export const PROMPT = `
-This is a transcript with timestamps.
-  
-  ${summary.prompt}
-  ${chapters.prompt}
-  
-  Format the output like so:
-  
-  \`\`\`md
-  ${summary.example}
-  ${chapters.example}
-  \`\`\`
+export const PROMPT = `This is a transcript with timestamps.
+
+${summary.prompt}
+${chapters.prompt}
+
+Format the output like so:
+
+    \`\`\`md
+    ${summary.example}
+    ${chapters.example}
+    \`\`\`
 `

--- a/src/transcription/whisper.js
+++ b/src/transcription/whisper.js
@@ -36,22 +36,7 @@ function getWhisperModel(modelType) {
   }
 }
 
-async function processLrcToTxt(finalPath) {
-  try {
-    const lrcContent = await readFile(`${finalPath}.lrc`, 'utf8')
-    const txtContent = lrcContent.split('\n')
-      .filter(line => !line.startsWith('[by:whisper.cpp]'))
-      .map(line => line.replace(/\[\d{2}:\d{2}\.\d{2}\]/g, match => match.slice(0, -4) + ']'))
-      .join('\n')
-    await writeFile(`${finalPath}.txt`, txtContent)
-    return txtContent
-  } catch (error) {
-    console.error('Error processing LRC to TXT:', error)
-    throw new Error('Failed to process LRC to TXT due to an internal error.')
-  }
-}
-
-export const callWhisper = async (finalPath, whisperModelType) => {
+export async function callWhisper(finalPath, whisperModelType) {
   try {
     const whisperModel = getWhisperModel(whisperModelType)
     await execPromise(`./whisper.cpp/main \
@@ -62,7 +47,12 @@ export const callWhisper = async (finalPath, whisperModelType) => {
     )
     console.log(`Whisper.cpp Model Selected:\n  - whisper.cpp/models/${whisperModel}`)
     console.log(`Transcript LRC file completed:\n  - ${finalPath}.lrc`)
-    const txtContent = await processLrcToTxt(finalPath)
+    const lrcContent = await readFile(`${finalPath}.lrc`, 'utf8')
+    const txtContent = lrcContent.split('\n')
+      .filter(line => !line.startsWith('[by:whisper.cpp]'))
+      .map(line => line.replace(/\[\d{2}:\d{2}\.\d{2}\]/g, match => match.slice(0, -4) + ']'))
+      .join('\n')
+    await writeFile(`${finalPath}.txt`, txtContent)
     console.log(`Transcript transformation completed:\n  - ${finalPath}.txt`)
     return txtContent
   } catch (error) {

--- a/src/utils/downloadAudio.js
+++ b/src/utils/downloadAudio.js
@@ -5,7 +5,7 @@ import { promisify } from 'node:util'
 
 const execFilePromise = promisify(execFile)
 
-export const downloadAudio = async (url, filename) => {
+export async function downloadAudio(url, filename) {
   try {
     const finalPath = `content/${filename}`
     const { stdout, stderr } = await execFilePromise('yt-dlp', [

--- a/src/utils/exports.js
+++ b/src/utils/exports.js
@@ -1,9 +1,0 @@
-// src/utils/exports.js
-
-import { generateMarkdown } from './generateMarkdown.js'
-import { downloadAudio } from './downloadAudio.js'
-import { runTranscription } from './runTranscription.js'
-import { runLLM } from './runLLM.js'
-import { cleanUpFiles } from './cleanUpFiles.js'
-
-export { generateMarkdown, downloadAudio, runTranscription, runLLM, cleanUpFiles }

--- a/src/utils/runLLM.js
+++ b/src/utils/runLLM.js
@@ -9,10 +9,9 @@ import { callOcto } from '../llms/octo.js'
 import { callLlama } from '../llms/llama.js'
 import { PROMPT } from '../llms/prompt.js'
 
-export const runLLM = async (finalPath, frontMatter, llmOption) => {
+export async function runLLM(finalPath, frontMatter, llmOption) {
   try {
     const transcriptContent = await readFile(`${finalPath}.txt`, 'utf8')
-
     const llmFunctions = {
       chatgpt: callChatGPT,
       claude: callClaude,

--- a/src/utils/runTranscription.js
+++ b/src/utils/runTranscription.js
@@ -4,8 +4,9 @@ import { readFile, writeFile } from 'node:fs/promises'
 import { callWhisper } from '../transcription/whisper.js'
 import { PROMPT } from '../llms/prompt.js'
 
-async function appendFinalContent(finalPath, txtContent, frontMatter) {
+export async function runTranscription(finalPath, whisperModelType, frontMatter = '') {
   try {
+    const txtContent = await callWhisper(finalPath, whisperModelType)
     let mdContent = frontMatter
     try {
       mdContent = await readFile(`${finalPath}.md`, 'utf8')
@@ -15,20 +16,9 @@ async function appendFinalContent(finalPath, txtContent, frontMatter) {
       }
     }
     const finalContent = `${mdContent}\n${PROMPT}\n## Transcript\n\n${txtContent}`
-    console.log(`Frontmatter, prompt, and transcript concatenated together:\n  - ${finalPath}-with-prompt.md`)
-    return finalContent
-  } catch (error) {
-    console.error('Error concatenating final content:', error)
-    throw new Error('Failed to read content from file')
-  }
-}
-
-export const runTranscription = async (finalPath, whisperModelType, frontMatter = '') => {
-  try {
-    const txtContent = await callWhisper(finalPath, whisperModelType)
-    const finalContent = await appendFinalContent(finalPath, txtContent, frontMatter)
     await writeFile(`${finalPath}-with-prompt.md`, finalContent)
     console.log(`\nMarkdown file with frontmatter, prompt, and transcript:\n  - ${finalPath}-with-prompt.md`)
+    return finalContent
   } catch (error) {
     console.error('Error in runTranscription:', error)
     if (error.message === 'Transcription process failed' && error.stderr) {


### PR DESCRIPTION
This continues the refactor started in #14:

- Most of the utility functions are now consolidated down to single functions.
- `processFile.js` and `processRSS.js` are now structured more closely to `processVideo.js`.
  - `downloadFileAudio` and `generateRSSMarkdown` are temporary stopgaps that will eventually be moved to their respective utility functions.
  - Conditional logic will be included within the utility functions to detect whether a YouTube URL, file path, or RSS feed has been passed.

One small additional feature is the inclusion of `skip` for RSS feeds.

- Previously, it was only possible to start processing at the beginning of end of the feed and continue on from there.
- This made it impossible to download individual episodes somewhere in the middle
- It was also impossible to process partial list of episodes from a feed, stop processing, and then restart at the same episode.

Example:

```bash
npm run autoshow -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --skip 1
```