### PR TITLE
Fix `lrcContent` Bug

### DIFF
--- a/src/commands/processVideo.js
+++ b/src/commands/processVideo.js
@@ -1,6 +1,5 @@
 // src/commands/processVideo.js
 
-import { writeFile } from 'node:fs/promises'
 import { generateMarkdown } from '../utils/generateMarkdown.js'
 import { downloadAudio } from '../utils/downloadAudio.js'
 import { runTranscription } from '../utils/runTranscription.js'
@@ -10,7 +9,6 @@ import { cleanUpFiles } from '../utils/cleanUpFiles.js'
 export async function processVideo(url, llmOption, transcriptionOption, options) {
   try {
     const { frontMatter, finalPath, filename } = await generateMarkdown(url)
-    await writeFile(`${finalPath}.md`, frontMatter)
     await downloadAudio(url, filename)
     await runTranscription(finalPath, transcriptionOption, options)
     await runLLM(finalPath, frontMatter, llmOption, options)

--- a/src/transcription/whisper.js
+++ b/src/transcription/whisper.js
@@ -47,7 +47,9 @@ export async function callWhisper(finalPath, whisperModelType) {                
     const lrcContent = await readFile(`${finalPath}.lrc`, 'utf8')                               // Read the contents of the generated LRC file
     const txtContent = lrcContent.split('\n')                                                   // Split the content into lines
       .filter(line => !line.startsWith('[by:whisper.cpp]'))                                     // Remove the Whisper.cpp attribution line
-      .map(line => line.replace(/\[\d{2}:\d{2}\.\d{2}\]/g, match => match.slice(0, -4) + ']'))  // Modify time stamps
+      .map(line => line.replace(                                                                // Modify time stamps
+        /\[(\d{2,3}):(\d{2})\.(\d{2})\]/g, (match, p1, p2) => `[${p1}:${p2}]`
+      ))
       .join('\n')                                                                               // Join the lines back together
     await writeFile(`${finalPath}.txt`, txtContent)                                             // Write the transformed content to a new text file
     console.log(`Transcript transformation completed:\n  - ${finalPath}.txt`)                   // Log the completion of the transformation

--- a/src/utils/generateMarkdown.js
+++ b/src/utils/generateMarkdown.js
@@ -3,6 +3,7 @@
 import { execFile } from 'node:child_process'
 import { promisify } from 'node:util'
 import { join } from 'node:path'
+import { writeFile } from 'node:fs/promises'
 
 const execFilePromise = promisify(execFile)
 
@@ -40,6 +41,7 @@ export async function generateMarkdown(url) {
       `coverImage: "${thumbnail}"`,
       "---\n"
     ].join('\n')
+    await writeFile(`${finalPath}.md`, frontMatter)
     console.log(`\nInitial markdown file created:\n  - ${finalPath}.md\n\n${frontMatter}`)
     return { frontMatter, finalPath, filename }
   } catch (error) {


### PR DESCRIPTION
Right now there's a bug in the transformation from `lrcContent` to `txtContent` in the `callWhisper` function.

- Milliseconds are not removed when the content exceeds 99 minutes.
- This PR fixes the regex that performs the transformation.

Other small change is moving ``await writeFile(`${finalPath}.md`, frontMatter)`` from `processVideo.js` to `generateMarkdown.js` similarly to the other utility functions.