### PR TITLE
Create Test Files and Add Ability to Configure Local LLM Model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ package-lock.json
 src/llms/models
 .idea
 build
+deno.lock

--- a/README.md
+++ b/README.md
@@ -85,19 +85,19 @@ git clone https://github.com/ggerganov/llama.cpp && \
 Run on a single YouTube video.
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper large
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk"
 ```
 
 Run on a YouTube playlist.
 
 ```bash
-npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXMh4DQBigyvHSRTf2CSj129"
+npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXPz0SoAVu8Rc1emAdGPbSbr"
 ```
 
 Run on a list of arbitrary URLs.
 
 ```bash
-npm run as -- --urls "content/examples/urls.md"
+npm run as -- --urls "content/example-urls.md"
 ```
 
 Run on a local audio or video file.
@@ -115,18 +115,18 @@ npm run as -- --rss "https://ajcwebdev.substack.com/feed"
 Use local LLM.
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --llama
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama
 ```
 
 Use 3rd party LLM providers.
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --chatgpt GPT_4o_MINI
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --claude CLAUDE_3_5_SONNET
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --chatgpt GPT_4o_MINI
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --claude CLAUDE_3_5_SONNET
 npm run as -- --video "https://www.youtube.com/watch?v=h41DF9GUqx4" --gemini GEMINI_1_5_PRO
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --cohere COMMAND_R_PLUS
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --mistral MISTRAL_LARGE
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo LLAMA_3_1_405B
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --cohere COMMAND_R_PLUS
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --mistral MISTRAL_LARGE
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo LLAMA_3_1_405B
 ```
 
 Example commands for all available CLI options can be found in [`docs/examples.md`](/docs/examples.md).

--- a/content/example-urls.md
+++ b/content/example-urls.md
@@ -1,2 +1,2 @@
-https://www.youtube.com/watch?v=jKB0EltG9Jo
-https://www.youtube.com/watch?v=RS-FuJ7rUsE
+https://www.youtube.com/watch?v=MORMZXEaONk
+https://www.youtube.com/watch?v=nXtaETBZ29g

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -25,6 +25,8 @@
   - [Deno](#deno)
   - [Bun](#bun)
 - [Makeshift Test Suite](#makeshift-test-suite)
+  - [Full Test Suite](#full-test-suite)
+  - [Partial Test Command for Local Services](#partial-test-command-for-local-services)
 - [Create Single Markdown File with Entire Project](#create-single-markdown-file-with-entire-project)
 
 ## Content and Feed Inputs
@@ -34,7 +36,7 @@
 Run on a single YouTube video.
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo"
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk"
 ```
 
 ### Process Multiple Videos in YouTube Playlist
@@ -42,7 +44,7 @@ npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo"
 Run on multiple YouTube videos in a playlist.
 
 ```bash
-npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXMh4DQBigyvHSRTf2CSj129"
+npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXPz0SoAVu8Rc1emAdGPbSbr"
 ```
 
 ### Process Multiple Videos Specified in a URLs File
@@ -116,23 +118,23 @@ For each model available for each provider, I have collected the following detai
 ### OpenAI's ChatGPT Models
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --chatgpt
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --chatgpt
 ```
 
 Select ChatGPT model:
 
 ```bash
 # Select GPT-4o mini model - https://platform.openai.com/docs/models/gpt-4o-mini
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --chatgpt GPT_4o_MINI
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --chatgpt GPT_4o_MINI
 
 # Select GPT-4o model - https://platform.openai.com/docs/models/gpt-4o
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --chatgpt GPT_4o
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --chatgpt GPT_4o
 
 # Select GPT-4 Turbo model - https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --chatgpt GPT_4_TURBO
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --chatgpt GPT_4_TURBO
 
 # Select GPT-4 model - https://platform.openai.com/docs/models/gpt-4-turbo-and-gpt-4
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --chatgpt GPT_4
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --chatgpt GPT_4
 ```
 
 | Model        | Context Window | Max Output | Input Tokens | Output Tokens | Batch Input | Batch Output |
@@ -145,81 +147,81 @@ npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --chatgpt GP
 ### Anthropic's Claude Models
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --claude
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --claude
 ```
 
 Select Claude model:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --claude CLAUDE_3_5_SONNET
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --claude CLAUDE_3_OPUS
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --claude CLAUDE_3_SONNET
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --claude CLAUDE_3_HAIKU
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --claude CLAUDE_3_5_SONNET
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --claude CLAUDE_3_OPUS
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --claude CLAUDE_3_SONNET
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --claude CLAUDE_3_HAIKU
 ```
 
 ### Google's Gemini Models
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --gemini
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --gemini
 ```
 
 Select Gemini model:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --gemini GEMINI_1_5_FLASH
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --gemini GEMINI_1_5_PRO
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --gemini GEMINI_1_5_FLASH
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --gemini GEMINI_1_5_PRO
 ```
 
 ### Cohere's Command Models
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --cohere
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --cohere
 ```
 
 Select Cohere model:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --cohere COMMAND_R
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --cohere COMMAND_R_PLUS
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --cohere COMMAND_R
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --cohere COMMAND_R_PLUS
 ```
 
 ### Mistral's Mistral Models
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --mistral
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --mistral
 ```
 
 Select Mistral model:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --mistral MIXTRAL_8x7b
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --mistral MIXTRAL_8x22b
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --mistral MISTRAL_LARGE
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --mistral MISTRAL_NEMO
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --mistral MIXTRAL_8x7b
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --mistral MIXTRAL_8x22b
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --mistral MISTRAL_LARGE
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --mistral MISTRAL_NEMO
 ```
 
 ### OctoAI's Models
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo
 ```
 
 Select Octo model:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo LLAMA_3_1_8B
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo LLAMA_3_1_70B
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo LLAMA_3_1_405B
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo MISTRAL_7B
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo MIXTRAL_8X_7B
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo NOUS_HERMES_MIXTRAL_8X_7B
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo WIZARD_2_8X_22B
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo LLAMA_3_1_8B
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo LLAMA_3_1_70B
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo LLAMA_3_1_405B
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo MISTRAL_7B
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo MIXTRAL_8X_7B
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo NOUS_HERMES_MIXTRAL_8X_7B
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo WIZARD_2_8X_22B
 ```
 
 ### Llama.cpp
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --llama
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama
 ```
 
 ## Transcription Options
@@ -229,13 +231,13 @@ Create a `.env` file and set API key as demonstrated in `.env.example` for `DEEP
 ### Deepgram
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --deepgram
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --deepgram
 ```
 
 ### Assembly
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --assembly
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --assembly
 ```
 
 Include speaker labels and number of speakers:
@@ -250,25 +252,25 @@ If neither the `--deepgram` or `--assembly` option is included for transcription
 
 ```bash
 # tiny model
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper tiny
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --whisper tiny
 
 # base model
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper base
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --whisper base
 
 # small model
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper small
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --whisper small
 
 # medium model
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper medium
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --whisper medium
 
 # large-v2 model
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper large
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --whisper large
 ```
 
 Run `whisper.cpp` in a Docker container with `--whisper-docker`:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper-docker tiny
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --whisper-docker tiny
 ```
 
 ## Docker Compose
@@ -277,7 +279,7 @@ This will run both `whisper.cpp` and the AutoShow Commander CLI in their own Doc
 
 ```bash
 docker-compose up --build -d
-docker-compose run autoshow --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper-docker base
+docker-compose run autoshow --video "https://www.youtube.com/watch?v=MORMZXEaONk" --whisper-docker base
 ```
 
 Currently working on the `llama.cpp` Docker integration so the entire project can be encapsulated in one local Docker Compose file.
@@ -287,55 +289,55 @@ Currently working on the `llama.cpp` Docker integration so the entire project ca
 Default includes summary and long chapters, equivalent to running this:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt summary longChapters
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt summary longChapters
 ```
 
 Create five title ideas:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt titles
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt titles
 ```
 
 Create a one sentence and one paragraph summary:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt summary
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt summary
 ```
 
 Create a short, one sentence description for each chapter that's 25 words or shorter.
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt shortChapters
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt shortChapters
 ```
 
 Create a one paragraph description for each chapter that's around 50 words.
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt mediumChapters
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt mediumChapters
 ```
 
 Create a two paragraph description for each chapter that's over 75 words.
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt longChapters
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt longChapters
 ```
 
 Create three key takeaways about the content:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt takeaways
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt takeaways
 ```
 
 Create ten questions about the content to check for comprehension:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt questions
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt questions
 ```
 
 Include all prompt options:
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt titles summary longChapters takeaways questions
+npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt titles summary longChapters takeaways questions
 ```
 
 ## Alternative JavaScript Runtimes
@@ -343,152 +345,35 @@ npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt tit
 ### Bun
 
 ```bash
-bun --env-file=.env src/autoshow.js \
-  --video "https://www.youtube.com/watch?v=jKB0EltG9Jo"
+bun bun-as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk"
 ```
 
 ### Deno
 
 ```bash
-LLAMA_MODEL="Meta-Llama-3.1-8B-Instruct.Q2_K.gguf" HUGGING_FACE_URL="https://huggingface.co/mradermacher/Meta-Llama-3.1-8B-Instruct-GGUF" \
-  deno run \
-  --allow-sys \
-  --allow-read \
-  --allow-run \
-  --allow-write \
-  --allow-env \
-  src/autoshow.js \
-  --video "https://www.youtube.com/watch?v=jKB0EltG9Jo"
+deno task deno-as --video "https://www.youtube.com/watch?v=MORMZXEaONk"
 ```
 
 ## Makeshift Test Suite
 
-Creating a robust and flexible test suite for this project is complex because of the range of network requests, file system operations, build steps, and 3rd party APIs involved.
+Creating a robust and flexible test suite for this project is complex because of the range of network requests, file system operations, build steps, and 3rd party APIs involved. A more thought out test suite will be created at some point, but in the mean time these are hacky but functional ways to test the majority of the project in a single go.
 
-A more thought out test suite will be created at some point, but in the mean time this is a ridiculous and hacky way to test the majority of the project in a single go.
+### Full Test Suite
 
 - You'll need API keys for all services to make it through this entire command.
 - Mostly uses transcripts of videos around one minute long and cheaper models when possible, so the total cost of running this for any given service should be at most only a few cents.
 
-<details>
-  <summary>Click for full test command</summary>
-
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/01---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXMh4DQBigyvHSRTf2CSj129" && \
-  mv content/2022-11-05-intro-to-teach-jenn-tech-prompt.md content/02---2022-11-05-intro-to-teach-jenn-tech-prompt.md && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/03---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --urls "content/example-urls.md" && \
-  mv content/2022-11-05-intro-to-teach-jenn-tech-prompt.md content/04---2022-11-05-intro-to-teach-jenn-tech-prompt.md && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/05---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --file "content/audio.mp3" && \
-  mv content/audio.mp3-prompt.md content/06---audio.mp3-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --chatgpt && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-chatgpt-shownotes.md content/07---2023-09-10-teach-jenn-tech-channel-trailer-chatgpt-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --chatgpt GPT_4o_MINI && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-chatgpt-shownotes.md content/08---2023-09-10-teach-jenn-tech-channel-trailer-chatgpt-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --claude && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-claude-shownotes.md content/09---2023-09-10-teach-jenn-tech-channel-trailer-claude-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --claude CLAUDE_3_SONNET && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-claude-shownotes.md content/10---2023-09-10-teach-jenn-tech-channel-trailer-claude-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --gemini && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-gemini-shownotes.md content/11---2023-09-10-teach-jenn-tech-channel-trailer-gemini-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --gemini GEMINI_1_5_FLASH && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-gemini-shownotes.md content/12---2023-09-10-teach-jenn-tech-channel-trailer-gemini-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --cohere && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-cohere-shownotes.md content/13---2023-09-10-teach-jenn-tech-channel-trailer-cohere-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --cohere COMMAND_R_PLUS && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-cohere-shownotes.md content/14---2023-09-10-teach-jenn-tech-channel-trailer-cohere-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --mistral && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-mistral-shownotes.md content/15---2023-09-10-teach-jenn-tech-channel-trailer-mistral-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --mistral MIXTRAL_8x7b && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-mistral-shownotes.md content/16---2023-09-10-teach-jenn-tech-channel-trailer-mistral-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-octo-shownotes.md content/17---2023-09-10-teach-jenn-tech-channel-trailer-octo-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --octo LLAMA_3_1_8B && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-octo-shownotes.md content/18---2023-09-10-teach-jenn-tech-channel-trailer-octo-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --llama && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/19---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --deepgram && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/20---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --deepgram --llama && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/21---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --assembly && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/22---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --assembly --llama && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/23---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --video "https://ajc.pics/audio/fsjam-short.mp3" --assembly --speaker-labels --speakers-expected 2 && \
-  mv content/2024-05-08-fsjam-short-prompt.md content/24---2024-05-08-fsjam-short-prompt.md && \
-  npm run as -- --video "https://ajc.pics/audio/fsjam-short.mp3" --assembly --speaker-labels --speakers-expected 2 --llama && \
-  mv content/2024-05-08-fsjam-short-llama-shownotes.md content/25---2024-05-08-fsjam-short-llama-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper tiny && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/26---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt titles && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/27---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt titles summary shortChapters mediumChapters longChapters takeaways questions && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/28---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt titles summary shortChapters takeaways questions --whisper tiny --llama && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/29---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXMh4DQBigyvHSRTf2CSj129" --prompt titles --whisper tiny --llama && \
-  mv content/2022-11-05-intro-to-teach-jenn-tech-llama-shownotes.md content/30---2022-11-05-intro-to-teach-jenn-tech-llama-shownotes.md && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/31---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --urls "content/example-urls.md" --prompt titles --whisper tiny --llama && \
-  mv content/2022-11-05-intro-to-teach-jenn-tech-llama-shownotes.md content/32---2022-11-05-intro-to-teach-jenn-tech-llama-shownotes.md && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/33---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --file "content/audio.mp3" --prompt titles --whisper tiny --llama && \
-  mv content/audio.mp3-llama-shownotes.md content/34---audio.mp3-llama-shownotes.md && \
-  npm run as -- --rss "https://ajcwebdev.substack.com/feed" && \
-  mv content/2021-05-10-thoughts-on-lambda-school-layoffs-prompt.md content/35---2021-05-10-thoughts-on-lambda-school-layoffs-prompt.md && \
-  npm run as -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --order newest --skip 94 --whisper tiny && \
-  mv content/2020-10-27-episode-0-the-fullstack-jamstack-podcast-with-anthony-campolo-and-christopher-burns-prompt.md content/36---2020-10-27-episode-0-the-fullstack-jamstack-podcast-with-anthony-campolo-and-christopher-burns-prompt.md && \
-  npm run as -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --order oldest --skip 94 --whisper tiny && \
-  mv content/2023-06-28-episode-94-clerk-with-james-perkins-prompt.md content/37---2023-06-28-episode-94-clerk-with-james-perkins-prompt.md
+npm run test-all
 ```
 
-</details>
+### Partial Test Command for Local Services
 
-<details>
-  <summary>Click for partial test command that doesn't use paid services</summary>
+This version of the test suite only uses Whisper for transcription and Llama.cpp for LLM operations.
 
 ```bash
-npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/01---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXMh4DQBigyvHSRTf2CSj129" && \
-  mv content/2022-11-05-intro-to-teach-jenn-tech-prompt.md content/02---2022-11-05-intro-to-teach-jenn-tech-prompt.md && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/03---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --urls "content/example-urls.md" && \
-  mv content/2022-11-05-intro-to-teach-jenn-tech-prompt.md content/04---2022-11-05-intro-to-teach-jenn-tech-prompt.md && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/05---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --file "content/audio.mp3" && \
-  mv content/audio.mp3-prompt.md content/06---audio.mp3-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --llama && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/09---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --whisper tiny && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/10---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt titles && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/11---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt titles summary shortChapters mediumChapters longChapters takeaways questions && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-prompt.md content/12---2023-09-10-teach-jenn-tech-channel-trailer-prompt.md && \
-  npm run as -- --video "https://www.youtube.com/watch?v=jKB0EltG9Jo" --prompt titles summary shortChapters takeaways questions --whisper tiny --llama && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/13---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXMh4DQBigyvHSRTf2CSj129" --prompt titles --whisper tiny --llama && \
-  mv content/2022-11-05-intro-to-teach-jenn-tech-llama-shownotes.md content/14---2022-11-05-intro-to-teach-jenn-tech-llama-shownotes.md && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/15---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --urls "content/example-urls.md" --prompt titles --whisper tiny --llama && \
-  mv content/2022-11-05-intro-to-teach-jenn-tech-llama-shownotes.md content/16---2022-11-05-intro-to-teach-jenn-tech-llama-shownotes.md && \
-  mv content/2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md content/17---2023-09-10-teach-jenn-tech-channel-trailer-llama-shownotes.md && \
-  npm run as -- --file "content/audio.mp3" --prompt titles --whisper tiny --llama && \
-  mv content/audio.mp3-llama-shownotes.md content/18---audio.mp3-llama-shownotes.md && \
-  npm run as -- --rss "https://ajcwebdev.substack.com/feed" && \
-  mv content/2021-05-10-thoughts-on-lambda-school-layoffs-prompt.md content/19---2021-05-10-thoughts-on-lambda-school-layoffs-prompt.md && \
-  npm run as -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --order newest --skip 94 --whisper tiny && \
-  mv content/2020-10-27-episode-0-the-fullstack-jamstack-podcast-with-anthony-campolo-and-christopher-burns-prompt.md content/20---2020-10-27-episode-0-the-fullstack-jamstack-podcast-with-anthony-campolo-and-christopher-burns-prompt.md && \
-  npm run as -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --order oldest --skip 94 --whisper tiny && \
-  mv content/2023-06-28-episode-94-clerk-with-james-perkins-prompt.md content/21---2023-06-28-episode-94-clerk-with-james-perkins-prompt.md
+npm run test-local
 ```
-
-</details>
 
 ## Create Single Markdown File with Entire Project
 

--- a/package.json
+++ b/package.json
@@ -20,9 +20,13 @@
   "scripts": {
     "autoshow": "node --env-file=.env --no-warnings src/autoshow.js",
     "as": "node --env-file=.env --no-warnings src/autoshow.js",
+    "bun-as": "bun --env-file=.env --no-warnings src/autoshow.js",
+    "deno-as": "deno run --allow-sys --allow-read --allow-run --allow-write --allow-env src/autoshow.js",
     "v": "node --env-file=.env --no-warnings src/autoshow.js --whisper large --video",
     "serve": "node --env-file=.env --no-warnings --watch server/index.js",
-    "fetch": "node --env-file=.env --no-warnings server/fetch.js"
+    "fetch": "node --env-file=.env --no-warnings server/fetch.js",
+    "test-local": "node --test test/local.test.js",
+    "test-all": "node --test test/all.test.js"
   },
   "dependencies": {
     "@anthropic-ai/sdk": "^0.26.0",

--- a/src/autoshow.js
+++ b/src/autoshow.js
@@ -71,7 +71,7 @@ program
   .option('--cohere [model]', 'Use Cohere for processing with optional model specification')
   .option('--mistral [model]', 'Use Mistral for processing')
   .option('--octo [model]', 'Use Octo for processing')
-  .option('--llama', 'Use Node Llama for processing')
+  .option('--llama [model]', 'Use Node Llama for processing with optional model specification')
   .option('--gemini [model]', 'Use Gemini for processing with optional model specification')
   .option('--noCleanUp', 'Do not delete intermediary files after processing')
 
@@ -155,6 +155,20 @@ const INQUIRER_PROMPT = [
   },
   {
     type: 'list',
+    name: 'llamaModel',
+    message: 'Select the LLAMA model you want to use:',
+    choices: [
+      { name: 'LLAMA 3 8B Q4 Model', value: 'LLAMA_3_1_8B_Q4_MODEL' },
+      { name: 'LLAMA 3 8B Q6 Model', value: 'LLAMA_3_1_8B_Q6_MODEL' },
+      { name: 'GEMMA 2 2B Q4 Model', value: 'GEMMA_2_2B_Q4_MODEL' },
+      { name: 'GEMMA 2 2B Q6 Model', value: 'GEMMA_2_2B_Q6_MODEL' },
+      { name: 'TINY LLAMA 1B Q4 Model', value: 'TINY_LLAMA_1B_Q4_MODEL' },
+      { name: 'TINY LLAMA 1B Q6 Model', value: 'TINY_LLAMA_1B_Q6_MODEL' },
+    ],
+    when: (answers) => answers.llmOpt === 'llama',
+  },
+  {
+    type: 'list',
     name: 'transcriptOpt',
     message: 'Select the transcription service you want to use:',
     choices: [
@@ -232,7 +246,7 @@ async function handleInteractivePrompt(options) {
   
   // Handle LLM options
   if (answers.llmOpt) {
-    options[answers.llmOpt] = true
+    options[answers.llmOpt] = answers.llmOpt === 'llama' ? answers.llamaModel : true
   }
   
   // Handle transcription options

--- a/src/commands/processFile.js
+++ b/src/commands/processFile.js
@@ -1,6 +1,6 @@
 // src/commands/processFile.js
 
-import { basename } from 'node:path'
+import { generateFileMarkdown } from '../utils/generateMarkdown.js'
 import { downloadFileAudio } from '../utils/downloadAudio.js'
 import { runTranscription } from '../utils/runTranscription.js'
 import { runLLM } from '../utils/runLLM.js'
@@ -16,9 +16,11 @@ import { cleanUpFiles } from '../utils/cleanUpFiles.js'
  */
 export async function processFile(filePath, llmOpt, transcriptOpt, options) {
   try {
-    // Download or convert the audio file and create frontmatter for markdown file
-    const finalPath = await downloadFileAudio(filePath)
-    const frontMatter = `---\ntitle: "${basename(filePath)}"\n---\n`
+    // Generate markdown for the file
+    const { frontMatter, finalPath, filename } = await generateFileMarkdown(filePath)
+
+    // Download or convert the audio file
+    await downloadFileAudio(filePath, filename)
 
     // Run transcription on the file and process the transcript with the selected LLM
     await runTranscription(finalPath, transcriptOpt, options, frontMatter)

--- a/src/llms/llama.js
+++ b/src/llms/llama.js
@@ -10,37 +10,72 @@ const execAsync = promisify(exec)
 
 // Define local model configurations
 const localModels = {
-  LLAMA_MODEL: "Meta-Llama-3.1-8B-Instruct.IQ4_XS.gguf",
-  LLAMA_HUGGING_FACE_URL: "https://huggingface.co/mradermacher/Meta-Llama-3.1-8B-Instruct-GGUF",
-  GEMMA_MODEL: "gemma-2-2b-it-IQ4_XS.gguf",
-  GEMMA_HUGGING_FACE_URL: "https://huggingface.co/lmstudio-community/gemma-2-2b-it-GGUF",
-}
-
-// Destructure GEMMA model details and set the model path
-const { GEMMA_MODEL, GEMMA_HUGGING_FACE_URL } = localModels
-const MODEL_PATH = `./src/llms/models/${GEMMA_MODEL}`
-
-// Check if GEMMA_MODEL and GEMMA_HUGGING_FACE_URL are set
-if (!GEMMA_MODEL || !GEMMA_HUGGING_FACE_URL) {
-  console.error('GEMMA_MODEL and GEMMA_HUGGING_FACE_URL must be set')
-  process.exit(1)
+  LLAMA_3_1_8B_Q4_MODEL: {
+    filename: "Meta-Llama-3.1-8B-Instruct.IQ4_XS.gguf",
+    url: "https://huggingface.co/mradermacher/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct.IQ4_XS.gguf"
+  },
+  LLAMA_3_1_8B_Q6_MODEL: {
+    filename: "Meta-Llama-3.1-8B-Instruct.Q6_K.gguf",
+    url: "https://huggingface.co/mradermacher/Meta-Llama-3.1-8B-Instruct-GGUF/resolve/main/Meta-Llama-3.1-8B-Instruct.Q6_K.gguf"
+  },
+  GEMMA_2_2B_Q4_MODEL: {
+    filename: "gemma-2-2b-it-IQ4_XS.gguf",
+    url: "https://huggingface.co/lmstudio-community/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-IQ4_XS.gguf"
+  },
+  GEMMA_2_2B_Q6_MODEL: {
+    filename: "gemma-2-2b-it-Q6_K.gguf",
+    url: "https://huggingface.co/lmstudio-community/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q6_K.gguf"
+  },
+  TINY_LLAMA_1B_Q4_MODEL: {
+    filename: "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf",
+    url: "https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf"
+  },
+  TINY_LLAMA_1B_Q6_MODEL: {
+    filename: "tinyllama-1.1b-chat-v1.0.Q6_K.gguf",
+    url: "https://huggingface.co/TheBloke/TinyLlama-1.1B-Chat-v1.0-GGUF/resolve/main/tinyllama-1.1b-chat-v1.0.Q6_K.gguf"
+  }
 }
 
 /**
  * Function to download the model if it doesn't exist.
- * @returns {Promise<void>}
+ * @param {string} [modelName='GEMMA_2_2B_Q4_MODEL'] - The name of the model to use.
+ * @returns {Promise<string>} - The path to the downloaded model.
  */
-async function downloadModel() {
-  if (existsSync(MODEL_PATH)) return console.log(`\nModel already exists: ${MODEL_PATH}`)
-  console.log(`Downloading ${GEMMA_MODEL}...`)
+async function downloadModel(modelName = 'GEMMA_2_2B_Q4_MODEL') {
+  // Get the model object from localModels using the provided modelName or default to GEMMA_2_2B_Q4_MODEL
+  const model = localModels[modelName] || localModels.GEMMA_2_2B_Q4_MODEL
+
+  // If no valid model is found, throw an error
+  if (!model) {
+    throw new Error(`Invalid model name: ${modelName}`)
+  }
+
+  // Construct the path where the model file should be stored
+  const modelPath = `./src/llms/models/${model.filename}`
+
+  // Check if the model file already exists
+  if (existsSync(modelPath)) {
+    console.log(`\nModel already exists: ${modelPath}`)
+    // Return the path if the model already exists
+    return modelPath
+  }
+
+  console.log(`\nDownloading ${model.filename}...`)
   try {
+    // Create the directory for storing models if it doesn't exist
     await mkdir('./src/llms/models', { recursive: true })
-    const { stderr } = await execAsync(
-      `curl -L ${GEMMA_HUGGING_FACE_URL}/resolve/main/${GEMMA_MODEL} -o ${MODEL_PATH}`
-    )
-    if (stderr) console.error('Error:', stderr)
+
+    // Download the model using curl
+    const { stderr } = await execAsync(`curl -L ${model.url} -o ${modelPath}`)
+
+    // If there's any stderr output, log it
+    if (stderr) console.log(stderr)
     console.log('Download completed')
+
+    // Return the path to the downloaded model
+    return modelPath
   } catch (err) {
+    // If an error occurs during download, log it and throw a new error
     console.error('Download failed:', err.message)
     throw new Error('Failed to download the model')
   }
@@ -50,16 +85,17 @@ async function downloadModel() {
  * Main function to call the local Llama model.
  * @param {string} promptAndTranscript - The combined prompt and transcript content.
  * @param {string} tempPath - The temporary file path to save the output.
+ * @param {string} [modelName='GEMMA_2_2B_Q4_MODEL'] - The name of the model to use.
  * @returns {Promise<void>}
  */
-export async function callLlama(promptAndTranscript, tempPath) {
+export async function callLlama(promptAndTranscript, tempPath, modelName = 'GEMMA_2_2B_Q4_MODEL') {
   try {
     // Ensure the model is downloaded
-    await downloadModel()
+    const modelPath = await downloadModel(modelName)
 
     // Initialize Llama and load the local model
     const llama = await getLlama()
-    const localModel = await llama.loadModel({ modelPath: MODEL_PATH })
+    const localModel = await llama.loadModel({ modelPath })
 
     // Create a context for the model and create a chat session
     const context = await localModel.createContext()
@@ -68,7 +104,8 @@ export async function callLlama(promptAndTranscript, tempPath) {
     // Generate a response and write the response to a temporary file
     const response = await session.prompt(promptAndTranscript)
     await writeFile(tempPath, response)
-    console.log(`\nTranscript saved to: ${tempPath}`)
+    console.log(`\nTranscript saved to:\n  - ${tempPath}`)
+    console.log(`\nModel used:\n  - ${modelName}\n`)
   } catch (error) {
     // Log and re-throw any errors that occur during the process
     console.error('Error:', error)

--- a/src/transcription/assembly.js
+++ b/src/transcription/assembly.js
@@ -1,10 +1,11 @@
 // src/transcription/assembly.js
 
 import { writeFile } from 'node:fs/promises'
+import { env } from 'node:process'
 import { AssemblyAI } from 'assemblyai'
 
 // Initialize the AssemblyAI client with API key from environment variables
-const client = new AssemblyAI({ apiKey: process.env.ASSEMBLY_API_KEY })
+const client = new AssemblyAI({ apiKey: env.ASSEMBLY_API_KEY })
 
 /**
  * Main function to handle transcription using AssemblyAI.

--- a/src/transcription/whisper.js
+++ b/src/transcription/whisper.js
@@ -86,7 +86,7 @@ async function callWhisperDocker(finalPath, modelName, whisperModel) {
       -of ${path.join(CONTENT_DIR, fileName)} \
       --output-lrc`
   )
-  console.log(`Transcript LRC file completed:\n  - ${finalPath}.lrc`)
+  console.log(`\nTranscript LRC file completed:\n  - ${finalPath}.lrc`)
 }
 
 /**
@@ -102,11 +102,11 @@ async function callWhisperMain(finalPath, modelName, whisperModel) {
   // Check if the model exists locally, download if not
   try {
     await access(modelPath)
-    console.log(`Whisper model found: ${modelName}`)
+    console.log(`\nWhisper model found:\n  - ${modelPath}`)
   } catch {
-    console.log(`Whisper model not found: ${modelName}. Downloading model: ${whisperModel}`)
+    console.log(`\nWhisper model not found: ${modelPath}\n  - Downloading model: ${whisperModel}`)
     await execPromise(`bash ./whisper.cpp/models/download-ggml-model.sh ${whisperModel}`)
-    console.log(`Model downloaded: ${modelName}`)
+    console.log(`  - Model downloaded: ${modelPath}`)
   }
 
   /**
@@ -115,5 +115,5 @@ async function callWhisperMain(finalPath, modelName, whisperModel) {
   await execPromise(
     `./whisper.cpp/main -m "whisper.cpp/models/${modelName}" -f "${finalPath}.wav" -of "${finalPath}" --output-lrc`
   )
-  console.log(`Whisper.cpp Model Selected:\n  - whisper.cpp/models/${modelName}\nTranscript LRC file completed:\n  - ${finalPath}.lrc`)
+  console.log(`Whisper.cpp Model Selected:\n  - ${modelPath}\n\nTranscript LRC file completed:\n  - ${finalPath}.lrc`)
 }

--- a/src/utils/downloadAudio.js
+++ b/src/utils/downloadAudio.js
@@ -49,10 +49,11 @@ export async function downloadAudio(url, filename) {
 /**
  * Function to process a local audio or video file.
  * @param {string} filePath - The path to the local file.
+ * @param {string} sanitizedFilename - The sanitized filename.
  * @returns {Promise<string>} - Returns the final path to the processed WAV file.
  * @throws {Error} - If the file type is unsupported or processing fails.
  */
-export async function downloadFileAudio(filePath) {
+export async function downloadFileAudio(filePath, sanitizedFilename) {
   // Define supported audio and video formats
   const supportedFormats = new Set([
     'wav', 'mp3', 'm4a', 'aac', 'ogg', 'flac', 'mp4', 'mkv', 'avi', 'mov', 'webm'
@@ -76,17 +77,18 @@ export async function downloadFileAudio(filePath) {
     }
     console.log(`Detected file type: ${fileType.ext}`)
 
+    const outputPath = `content/${sanitizedFilename}.wav`    
     // If the file is not already a WAV, convert it
     if (fileType.ext !== 'wav') {
       await execPromise(
-        `${ffmpeg} -i "${filePath}" -acodec pcm_s16le -ar 16000 -ac 1 "${filePath}.wav"`
+        `${ffmpeg} -i "${filePath}" -acodec pcm_s16le -ar 16000 -ac 1 "${outputPath}"`
       )
-      console.log(`Converted ${filePath} to ${filePath}.wav`)
+      console.log(`Converted ${filePath} to ${outputPath}`)
     } else {
       // If it's already a WAV, just copy it
-      await execPromise(`cp "${filePath}" "${filePath}.wav"`)
+      await execPromise(`cp "${filePath}" "${outputPath}"`)
     }
-    return filePath
+    return outputPath
   } catch (error) {
     console.error('Error in downloadFileAudio:', error.message)
     throw error

--- a/src/utils/downloadAudio.js
+++ b/src/utils/downloadAudio.js
@@ -23,6 +23,7 @@ export async function downloadAudio(url, filename) {
 
     // Execute yt-dlp to download the audio
     const { stderr } = await execFilePromise('yt-dlp', [
+      '--no-warnings',
       '--restrict-filenames',
       '--extract-audio',
       '--audio-format', 'wav',

--- a/src/utils/runLLM.js
+++ b/src/utils/runLLM.js
@@ -57,7 +57,7 @@ export async function runLLM(finalPath, frontMatter, llmOpt, options) {
     } else {
       // If no LLM is selected, just write the prompt and transcript
       await writeFile(`${finalPath}-prompt.md`, `${frontMatter}\n${promptAndTranscript}`)
-      console.log(`Created original structure: ${finalPath}-prompt.md`)
+      console.log(`\nFinal markdown file with prompt:\n  - ${finalPath}-prompt.md`)
     }
   } catch (error) {
     console.error('Error running LLM:', error)

--- a/test/all.test.js
+++ b/test/all.test.js
@@ -1,0 +1,205 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const commands = [
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk"',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '01---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXPz0SoAVu8Rc1emAdGPbSbr"',
+    expectedFiles: [
+      { file: '2024-09-24-ep1-fsjam-podcast-prompt.md', newName: '02---2024-09-24-ep1-fsjam-podcast-prompt.md' },
+      { file: '2024-09-24-ep0-fsjam-podcast-prompt.md', newName: '03---2024-09-24-ep0-fsjam-podcast-prompt.md' }
+    ]
+  },
+  {
+    cmd: 'npm run as -- --urls "content/example-urls.md"',
+    expectedFiles: [
+      { file: '2024-09-24-ep1-fsjam-podcast-prompt.md', newName: '04---2024-09-24-ep1-fsjam-podcast-prompt.md' },
+      { file: '2024-09-24-ep0-fsjam-podcast-prompt.md', newName: '05---2024-09-24-ep0-fsjam-podcast-prompt.md' }
+    ]
+  },
+  {
+    cmd: 'npm run as -- --file "content/audio.mp3"',
+    expectedFile: 'audio-prompt.md',
+    newName: '06---audio-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --chatgpt',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-chatgpt-shownotes.md',
+    newName: '07---2024-09-24-ep0-fsjam-podcast-chatgpt-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --chatgpt GPT_4o_MINI',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-chatgpt-shownotes.md',
+    newName: '08---2024-09-24-ep0-fsjam-podcast-chatgpt-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --claude',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-claude-shownotes.md',
+    newName: '09---2024-09-24-ep0-fsjam-podcast-claude-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --claude CLAUDE_3_SONNET',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-claude-shownotes.md',
+    newName: '10---2024-09-24-ep0-fsjam-podcast-claude-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --gemini',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-gemini-shownotes.md',
+    newName: '11---2024-09-24-ep0-fsjam-podcast-gemini-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --gemini GEMINI_1_5_FLASH',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-gemini-shownotes.md',
+    newName: '12---2024-09-24-ep0-fsjam-podcast-gemini-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --cohere',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-cohere-shownotes.md',
+    newName: '13---2024-09-24-ep0-fsjam-podcast-cohere-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --cohere COMMAND_R_PLUS',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-cohere-shownotes.md',
+    newName: '14---2024-09-24-ep0-fsjam-podcast-cohere-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --mistral',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-mistral-shownotes.md',
+    newName: '15---2024-09-24-ep0-fsjam-podcast-mistral-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --mistral MIXTRAL_8x7b',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-mistral-shownotes.md',
+    newName: '16---2024-09-24-ep0-fsjam-podcast-mistral-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-octo-shownotes.md',
+    newName: '17---2024-09-24-ep0-fsjam-podcast-octo-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --octo LLAMA_3_1_8B',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-octo-shownotes.md',
+    newName: '18---2024-09-24-ep0-fsjam-podcast-octo-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md',
+    newName: '19---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --deepgram',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '20---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --deepgram --llama',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md',
+    newName: '21---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --assembly',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '22---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --assembly --llama',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md',
+    newName: '23---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://ajc.pics/audio/fsjam-short.mp3" --assembly --speaker-labels --speakers-expected 2',
+    expectedFile: '2024-05-08-fsjam-short-prompt.md',
+    newName: '24---2024-05-08-fsjam-short-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://ajc.pics/audio/fsjam-short.mp3" --assembly --speaker-labels --speakers-expected 2 --llama',
+    expectedFile: '2024-05-08-fsjam-short-llama-shownotes.md',
+    newName: '25---2024-05-08-fsjam-short-llama-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --whisper tiny',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '26---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt titles',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '27---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt titles summary shortChapters mediumChapters longChapters takeaways questions',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '28---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt titles summary shortChapters takeaways questions --whisper tiny --llama',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md',
+    newName: '29---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXPz0SoAVu8Rc1emAdGPbSbr" --prompt titles --whisper tiny --llama',
+    expectedFiles: [
+      { file: '2024-09-24-ep1-fsjam-podcast-llama-shownotes.md', newName: '30---2024-09-24-ep1-fsjam-podcast-llama-shownotes.md' },
+      { file: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md', newName: '31---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md' }
+    ]
+  },
+  {
+    cmd: 'npm run as -- --urls "content/example-urls.md" --prompt titles --whisper tiny --llama',
+    expectedFiles: [
+      { file: '2024-09-24-ep1-fsjam-podcast-llama-shownotes.md', newName: '32---2024-09-24-ep1-fsjam-podcast-llama-shownotes.md' },
+      { file: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md', newName: '33---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md' }
+    ]
+  },
+  {
+    cmd: 'npm run as -- --file "content/audio.mp3" --prompt titles --whisper tiny --llama',
+    expectedFile: 'audio-llama-shownotes.md',
+    newName: '34---audio-llama-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --rss "https://ajcwebdev.substack.com/feed"',
+    expectedFile: '2021-05-10-thoughts-on-lambda-school-layoffs-prompt.md',
+    newName: '35---2021-05-10-thoughts-on-lambda-school-layoffs-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --order newest --skip 94 --whisper tiny',
+    expectedFile: '2020-10-27-episode-0-the-fullstack-jamstack-podcast-with-anthony-campolo-and-christopher-burns-prompt.md',
+    newName: '36---2020-10-27-episode-0-the-fullstack-jamstack-podcast-with-anthony-campolo-and-christopher-burns-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --order oldest --skip 94 --whisper tiny',
+    expectedFile: '2023-06-28-episode-94-clerk-with-james-perkins-prompt.md',
+    newName: '37---2023-06-28-episode-94-clerk-with-james-perkins-prompt.md'
+  }
+]
+
+test('Autoshow Command Tests', async (t) => {
+  for (const [index, command] of commands.entries()) {
+    await t.test(`should run command ${index + 1} successfully`, async () => {
+      // Run the command
+      execSync(command.cmd, { stdio: 'inherit' })
+      if (Array.isArray(command.expectedFiles)) {
+        for (const { file, newName } of command.expectedFiles) {
+          const filePath = path.join('content', file)
+          assert.strictEqual(fs.existsSync(filePath), true, `Expected file ${file} was not created`)
+          const newPath = path.join('content', newName)
+          fs.renameSync(filePath, newPath)
+          assert.strictEqual(fs.existsSync(newPath), true, `File was not renamed to ${newName}`)
+        }
+      } else {
+        const filePath = path.join('content', command.expectedFile)
+        assert.strictEqual(fs.existsSync(filePath), true, `Expected file ${command.expectedFile} was not created`)
+        const newPath = path.join('content', command.newName)
+        fs.renameSync(filePath, newPath)
+        assert.strictEqual(fs.existsSync(newPath), true, `File was not renamed to ${command.newName}`)
+      }
+    })
+  }
+})

--- a/test/local.test.js
+++ b/test/local.test.js
@@ -1,0 +1,118 @@
+// test/autoshow.test.js
+
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { execSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+const commands = [
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk"',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '01---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXPz0SoAVu8Rc1emAdGPbSbr"',
+    expectedFiles: [
+      { file: '2024-09-24-ep1-fsjam-podcast-prompt.md', newName: '02---2024-09-24-ep1-fsjam-podcast-prompt.md' },
+      { file: '2024-09-24-ep0-fsjam-podcast-prompt.md', newName: '03---2024-09-24-ep0-fsjam-podcast-prompt.md' }
+    ]
+  },
+  {
+    cmd: 'npm run as -- --urls "content/example-urls.md"',
+    expectedFiles: [
+      { file: '2024-09-24-ep1-fsjam-podcast-prompt.md', newName: '04---2024-09-24-ep1-fsjam-podcast-prompt.md' },
+      { file: '2024-09-24-ep0-fsjam-podcast-prompt.md', newName: '05---2024-09-24-ep0-fsjam-podcast-prompt.md' }
+    ]
+  },
+  {
+    cmd: 'npm run as -- --file "content/audio.mp3"',
+    expectedFile: 'audio-prompt.md',
+    newName: '06---audio-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md',
+    newName: '07---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --whisper tiny',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '08---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt titles',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '09---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt titles summary shortChapters mediumChapters longChapters takeaways questions',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-prompt.md',
+    newName: '10---2024-09-24-ep0-fsjam-podcast-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt titles summary shortChapters takeaways questions --whisper tiny --llama',
+    expectedFile: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md',
+    newName: '11---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --playlist "https://www.youtube.com/playlist?list=PLCVnrVv4KhXPz0SoAVu8Rc1emAdGPbSbr" --prompt titles --whisper tiny --llama',
+    expectedFiles: [
+      { file: '2024-09-24-ep1-fsjam-podcast-llama-shownotes.md', newName: '12---2024-09-24-ep1-fsjam-podcast-llama-shownotes.md' },
+      { file: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md', newName: '13---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md' }
+    ]
+  },
+  {
+    cmd: 'npm run as -- --urls "content/example-urls.md" --prompt titles --whisper tiny --llama',
+    expectedFiles: [
+      { file: '2024-09-24-ep1-fsjam-podcast-llama-shownotes.md', newName: '14---2024-09-24-ep1-fsjam-podcast-llama-shownotes.md' },
+      { file: '2024-09-24-ep0-fsjam-podcast-llama-shownotes.md', newName: '15---2024-09-24-ep0-fsjam-podcast-llama-shownotes.md' }
+    ]
+  },
+  {
+    cmd: 'npm run as -- --file "content/audio.mp3" --prompt titles --whisper tiny --llama',
+    expectedFile: 'audio-llama-shownotes.md',
+    newName: '16---audio-llama-shownotes.md'
+  },
+  {
+    cmd: 'npm run as -- --rss "https://ajcwebdev.substack.com/feed"',
+    expectedFile: '2021-05-10-thoughts-on-lambda-school-layoffs-prompt.md',
+    newName: '17---2021-05-10-thoughts-on-lambda-school-layoffs-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --order newest --skip 94 --whisper tiny',
+    expectedFile: '2020-10-27-episode-0-the-fullstack-jamstack-podcast-with-anthony-campolo-and-christopher-burns-prompt.md',
+    newName: '18---2020-10-27-episode-0-the-fullstack-jamstack-podcast-with-anthony-campolo-and-christopher-burns-prompt.md'
+  },
+  {
+    cmd: 'npm run as -- --rss "https://feeds.transistor.fm/fsjam-podcast/" --order oldest --skip 94 --whisper tiny',
+    expectedFile: '2023-06-28-episode-94-clerk-with-james-perkins-prompt.md',
+    newName: '19---2023-06-28-episode-94-clerk-with-james-perkins-prompt.md'
+  }
+]
+
+test('Autoshow Command Tests', async (t) => {
+  for (const [index, command] of commands.entries()) {
+    await t.test(`should run command ${index + 1} successfully`, async () => {
+      // Run the command
+      execSync(command.cmd, { stdio: 'inherit' })
+
+      if (Array.isArray(command.expectedFiles)) {
+        for (const { file, newName } of command.expectedFiles) {
+          const filePath = path.join('content', file)
+          assert.strictEqual(fs.existsSync(filePath), true, `Expected file ${file} was not created`)
+          const newPath = path.join('content', newName)
+          fs.renameSync(filePath, newPath)
+          assert.strictEqual(fs.existsSync(newPath), true, `File was not renamed to ${newName}`)
+        }
+      } else {
+        const filePath = path.join('content', command.expectedFile)
+        assert.strictEqual(fs.existsSync(filePath), true, `Expected file ${command.expectedFile} was not created`)
+        const newPath = path.join('content', command.newName)
+        fs.renameSync(filePath, newPath)
+        assert.strictEqual(fs.existsSync(newPath), true, `File was not renamed to ${command.newName}`)
+      }
+    })
+  }
+})


### PR DESCRIPTION
Two test files now exist:

- `test/local.test.js` for testing all commands using Whisper and Llama.cpp
- `test/all.test.js` for testing all commands including 3rd party transcription and LLM services

```bash
npm run test-local
npm run test-all
```

Different models can now be selected at the command line for local inference with Llama.cpp. There's only a few options right now but this list will grow as I test and add more models.

```bash
npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama LLAMA_3_1_8B_Q4_MODEL
npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama LLAMA_3_1_8B_Q6_MODEL
npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama GEMMA_2_2B_Q4_MODEL
npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama GEMMA_2_2B_Q6_MODEL
npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama TINY_LLAMA_1B_Q4_MODEL
npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --llama TINY_LLAMA_1B_Q6_MODEL
```

Defaults to `GEMMA_2_2B_Q4_MODEL` if no model option is passed.