### PR TITLE
Add `--date` and `--lastDays` RSS options

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -181,10 +181,43 @@ Process multiple RSS feeds:
 
 ```bash
 npm run as -- \
-  --rss "https://ajcwebdev.substack.com/feed" \
-  --rss "https://feeds.transistor.fm/fsjam-podcast/" \
   --last 1 \
-  --whisper tiny
+  --whisper tiny \
+  --rss "https://ajcwebdev.substack.com/feed" \
+  "https://feeds.transistor.fm/fsjam-podcast/"
+```
+
+Download episodes from a specific date:
+
+```bash
+npm run as -- \
+  --rss "https://ajcwebdev.substack.com/feed" \
+  --date 2021-05-10
+```
+
+Download episodes from multiple dates:
+
+```bash
+npm run as -- \
+  --rss "https://ajcwebdev.substack.com/feed" \
+  --date 2021-05-10 2022-05-10
+```
+
+Download episodes from multiple dates on multiple RSS feeds:
+
+```bash
+npm run as -- \
+  --rss "https://ajcwebdev.substack.com/feed" \
+  "https://feeds.transistor.fm/fsjam-podcast/" \
+  --date 2021-05-10 2022-05-10
+```
+
+Download episodes from a specific number of previous days, for example to download episodes from the last 7 days:
+
+```bash
+npm run as -- \
+  --rss "https://ajcwebdev.substack.com/feed" \
+  --lastDays 7
 ```
 
 ## Language Model (LLM) Options

--- a/src/cli/commander.ts
+++ b/src/cli/commander.ts
@@ -68,6 +68,8 @@ program
   .option('--order <order>', 'Specify the order for RSS feed processing (newest or oldest)')
   .option('--skip <number>', 'Number of items to skip when processing RSS feed', parseInt)
   .option('--last <number>', 'Number of most recent items to process (overrides --order and --skip)', parseInt)
+  .option('--date <dates...>', 'Process items from these dates (YYYY-MM-DD)')
+  .option('--lastDays <number>', 'Number of days to look back for items', parseInt)
   .option('--info', 'Skip processing and write metadata to JSON objects (supports --urls, --rss, --playlist, --channel)')
   // Transcription service options
   .option('--whisper [model]', 'Use Whisper.cpp for transcription with optional model specification')

--- a/src/types/main.ts
+++ b/src/types/main.ts
@@ -99,6 +99,12 @@ export type ProcessingOptions = {
   /** Number of most recent items to process (overrides --order and --skip). */
   last?: number
 
+  /** Date of RSS items to process. */
+  date?: string[]
+
+  /** Number of previous days to check for RSS items to process. */
+  lastDays?: number
+
   /** Whether to run in interactive mode. */
   interactive?: boolean
 }

--- a/src/utils/validate-option.ts
+++ b/src/utils/validate-option.ts
@@ -64,4 +64,30 @@ export function validateRSSOptions(options: ProcessingOptions): void {
     err("Error: The --order option must be either 'newest' or 'oldest'.")
     process.exit(1)
   }
+
+  if (options.lastDays !== undefined) {
+    if (!Number.isInteger(options.lastDays) || options.lastDays < 1) {
+      err('Error: The --lastDays option must be a positive integer.')
+      process.exit(1)
+    }
+    if (options.last !== undefined || options.skip !== undefined || options.order !== undefined || (options.date && options.date.length > 0)) {
+      err('Error: The --lastDays option cannot be used with --last, --skip, --order, or --date.')
+      process.exit(1)
+    }
+  }
+
+  if (options.date && options.date.length > 0) {
+    const dateRegex = /^\d{4}-\d{2}-\d{2}$/
+    for (const d of options.date) {
+      if (!dateRegex.test(d)) {
+        err(`Error: Invalid date format "${d}". Please use YYYY-MM-DD format.`)
+        process.exit(1)
+      }
+    }
+
+    if (options.last !== undefined || options.skip !== undefined || options.order !== undefined) {
+      err('Error: The --date option cannot be used with --last, --skip, or --order.')
+      process.exit(1)
+    }
+  }
 }


### PR DESCRIPTION
Download episodes from a specific date:

```bash
npm run as -- \
  --rss "https://ajcwebdev.substack.com/feed" \
  --date 2021-05-10
```

Download episodes from multiple dates:

```bash
npm run as -- \
  --rss "https://ajcwebdev.substack.com/feed" \
  --date 2021-05-10 2022-05-10
```

Download episodes from multiple dates on multiple RSS feeds:

```bash
npm run as -- \
  --rss "https://ajcwebdev.substack.com/feed" \
  "https://feeds.transistor.fm/fsjam-podcast/" \
  --date 2021-05-10 2022-05-10
```

Download episodes from a specific number of previous days, for example to download episodes from the last 7 days:

```bash
npm run as -- \
  --rss "https://ajcwebdev.substack.com/feed" \
  --lastDays 7