### PR TITLE
Add `--printPrompt` and `--customPrompt` options

### DIFF
--- a/.github/Dockerfile
+++ b/.github/Dockerfile
@@ -3,18 +3,15 @@
 # ---------------------------------------------------
 # 1) Node base image
 # ---------------------------------------------------
+
 FROM node:22 AS base
+
 RUN apt-get update && apt-get install -y \
-    ffmpeg \
-    git \
-    make \
-    curl \
-    docker.io \
-    ca-certificates \
-    cmake \
-    libopenblas-dev \
- && rm -rf /var/lib/apt/lists/*
+    ffmpeg git make curl docker.io ca-certificates cmake \
+    libopenblas-dev && rm -rf /var/lib/apt/lists/*
+
 RUN update-ca-certificates
+
 WORKDIR /usr/src/app
 
 # Install yt-dlp
@@ -44,8 +41,10 @@ RUN chmod +x /usr/src/app/docker-entrypoint.sh
 # ---------------------------------------------------
 # 2) Setup Ollama with models
 # ---------------------------------------------------
+
 FROM ollama/ollama:latest AS ollama
 WORKDIR /root/.ollama
+
 # Start Ollama server and pull models
 RUN ollama serve & \
     sleep 10 && \
@@ -55,7 +54,9 @@ RUN ollama serve & \
 # ---------------------------------------------------
 # 3) Final stage combining everything
 # ---------------------------------------------------
+
 FROM base
+
 # Copy Ollama binary and the pre-downloaded models
 COPY --from=ollama /bin/ollama /usr/local/bin/ollama
 COPY --from=ollama /root/.ollama /root/.ollama

--- a/content/custom-prompt.md
+++ b/content/custom-prompt.md
@@ -1,0 +1,2 @@
+Write a stand-up comedy routine based on this transcript.
+

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -569,6 +569,18 @@ Include all prompt options:
 npm run as -- --video "https://www.youtube.com/watch?v=MORMZXEaONk" --prompt titles summary longChapters takeaways questions
 ```
 
+### Print Select Prompts without Process Commands
+
+```bash
+npm run as -- --printPrompt summary longChapters
+```
+
+### Write a Custom Prompt
+
+```bash
+npm run as -- --file "content/audio.mp3" --customPrompt "content/custom-prompt.md" --chatgpt
+```
+
 ## Test Suite
 
 Integration test.

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -107,7 +107,7 @@ npm run as -- \
   --order oldest \
   --skip 2 \
   --last 5 \
-  --whisperDocker small \
+  --whisper base \
   --chatgpt GPT_4_TURBO \
   --prompt summary shortChapters \
   --noCleanUp
@@ -119,7 +119,7 @@ Here’s what’s happening in this single command:
 2. **Order**: Starts from the oldest videos in the channel rather than the most recent.
 3. **Skip**: Skips the first 2 videos from that oldest-first sequence.
 4. **Last**: Processes the next 5 videos (after skipping).
-5. **Transcription**: Uses the `--whisperDocker small` model to transcribe each video in a Docker container.
+5. **Transcription**: Uses the `--whisper base` model to transcribe each video in a Docker container.
 6. **LLM**: Uses OpenAI ChatGPT’s GPT-4 Turbo model (`--chatgpt GPT_4_TURBO`) to process the transcripts.
 7. **Prompt**: Generates both a summary and short chapter descriptions (`--prompt summary shortChapters`).
 8. **No Clean Up**: Keeps any intermediary or downloaded files around (`--noCleanUp`) so you can inspect them after the run.

--- a/scripts/cleanContent.ts
+++ b/scripts/cleanContent.ts
@@ -9,7 +9,7 @@ const execAsync = promisify(exec)
 async function cleanContent() {
   try {
     const { stdout, stderr } = await execAsync(
-      'find content -type f -not \\( -name ".gitkeep" -o -name "audio.mp3" -o -name "example-urls.md" \\) -delete'
+      'find content -type f -not \\( -name ".gitkeep" -o -name "audio.mp3" -o -name "example-urls.md" -o -name "custom-prompt.md" \\) -delete'
     )
     if (stderr) {
       err('Error:', stderr)

--- a/src/cli/commander.ts
+++ b/src/cli/commander.ts
@@ -20,6 +20,7 @@ import { processChannel } from '../process-commands/channel'
 import { processURLs } from '../process-commands/urls'
 import { processFile } from '../process-commands/file'
 import { processRSS } from '../process-commands/rss'
+import { generatePrompt } from '../process-steps/04-select-prompt'
 import { validateOption, isValidAction, validateRSSAction } from '../utils/validate-option'
 import { ACTION_OPTIONS, LLM_OPTIONS, TRANSCRIPT_OPTIONS } from '../utils/globals'
 import { l, err, logCompletionSeparator } from '../utils/logging'
@@ -82,6 +83,8 @@ program
   .option('--groq [model]', 'Use Groq for processing with optional model specification')
   // Utility options
   .option('--prompt <sections...>', 'Specify prompt sections to include')
+  .option('--printPrompt <sections...>', 'Print the prompt sections without processing')
+  .option('--customPrompt <filePath>', 'Use a custom prompt from a markdown file')
   .option('--noCleanUp', 'Do not delete intermediary files after processing')
   // Add examples and additional help text
   .addHelpText(
@@ -110,6 +113,12 @@ program.action(async (options: ProcessingOptions) => {
   l.opts(`Options received at beginning of command:\n`)
   l.opts(JSON.stringify(options, null, 2))
   l.opts(``)
+
+  if (options.printPrompt) {
+    const prompt = await generatePrompt(options.printPrompt)
+    console.log(prompt)
+    exit(0)
+  }
 
   // Ensure options.item is always an array if provided via command line
   if (options.item && !Array.isArray(options.item)) {

--- a/src/process-steps/05-run-llm.ts
+++ b/src/process-steps/05-run-llm.ts
@@ -108,7 +108,7 @@ export async function runLLM(
     const transcript = `## Transcript\n\n${tempTranscript}`
 
     // Generate and combine prompt with transcript
-    const prompt = generatePrompt(options.prompt)
+    const prompt = await generatePrompt(options.prompt, options.customPrompt)
     const promptAndTranscript = `${prompt}${transcript}`
 
     if (llmServices) {

--- a/src/server/tests/fetch-all.ts
+++ b/src/server/tests/fetch-all.ts
@@ -2,7 +2,7 @@
 
 import fs from 'fs/promises'
 import path from 'path'
-import { l, err } from '../../../src/utils/logging'
+import { l, err } from '../../utils/logging'
 
 const BASE_URL = 'http://localhost:3000'
 const OUTPUT_DIR = 'content'

--- a/src/server/tests/fetch-local.ts
+++ b/src/server/tests/fetch-local.ts
@@ -2,7 +2,7 @@
 
 import fs from 'fs/promises'
 import path from 'path'
-import { l, err } from '../../../src/utils/logging'
+import { l, err } from '../../utils/logging'
 
 const BASE_URL = 'http://localhost:3000'
 const OUTPUT_DIR = 'content'

--- a/src/types/process.ts
+++ b/src/types/process.ts
@@ -82,6 +82,12 @@ export type ProcessingOptions = {
   /** Array of prompt sections to include (e.g., ['titles', 'summary']). */
   prompt?: string[]
 
+  /** Print selected prompts to the terminal without running any process commands. */
+  printPrompt?: string[]
+
+  /** Use a custom prompt saved in a markdown file */
+  customPrompt?: string
+
   /** The selected LLM option. */
   llmServices?: LLMServices
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -59,7 +59,7 @@
   },
   "include": [
     "src/**/*",                                   // Include all files in 'src' directory
-    "tests/**/*"                                  // Include all files in 'tests' directory
+    "test/**/*"                                   // Include all files in 'test' directory
   ],
   "exclude": [
     "node_modules",                               // Exclude 'node_modules' directory


### PR DESCRIPTION
Closes #58 and #67.

### Print Selected Prompts without Process Commands

```bash
npm run as -- \
  --printPrompt summary longChapters
```

### Write a Custom Prompt

```bash
npm run as -- \
  --file "content/audio.mp3" \
  --customPrompt "content/custom-prompt.md" \
  --chatgpt
```